### PR TITLE
Ship README.md and requirements.txt inside the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,13 @@
+# setup.py reads these at build time, so they must be inside the source
+# distribution or building a wheel from the sdist fails.
+include README.md
+include README.rst
+include requirements.txt
+include CHANGELOG.md
+include LICENSE
+
 recursive-exclude data *
 recursive-exclude result *
 recursive-exclude misc *
+recursive-exclude examples *
 exclude version_history.py

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,26 @@ def get_version():
     return default_ver
 
 def get_requirements():
-    with open('requirements.txt') as req:
-        return req.read().splitlines()
+    try:
+        with open('requirements.txt') as req:
+            return [line.strip() for line in req if line.strip() and not line.startswith('#')]
+    except FileNotFoundError:
+        # Keep the build working if the file is missing from a source tree.
+        return ['numpy', 'pandas', 'scipy', 'matplotlib', 'seaborn']
+
+
+def get_long_description():
+    for filename, content_type in (('README.md', 'text/markdown'),
+                                   ('README.rst', 'text/x-rst')):
+        try:
+            with open(filename, encoding='utf-8') as handle:
+                return handle.read(), content_type
+        except FileNotFoundError:
+            continue
+    return '', 'text/plain'
+
+
+LONG_DESCRIPTION, LONG_DESCRIPTION_TYPE = get_long_description()
 
 setup(
     name='hints-kmcs',
@@ -22,8 +40,8 @@ setup(
     author='Amin Akhshi',
     author_email='amin.akhshi@gmail.com',
     description='A package for calculating pairwise and higher-order interactions of N-dimensional state variables from measured time series',
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type=LONG_DESCRIPTION_TYPE,
     url='https://github.com/aminakhshi/hints',
     packages = find_packages(exclude=["misc*", "result*", "data*", "tests*", "examples*"]),
     install_requires=get_requirements(),


### PR DESCRIPTION
`python -m build` failed with `FileNotFoundError: README.md` when building the wheel from the source distribution.

`setup.py` reads `README.md` (long description) and `requirements.txt` (install_requires) at build time, but `MANIFEST.in` contained only exclusions, so neither shipped in the sdist.

This is not new in 0.1.3 — the same `setup.py` is in 0.1.2 on PyPI, so `pip install --no-binary :all: hints-kmcs` fails there too. It is masked because a wheel is published alongside and pip prefers it.

**Changes**
- `MANIFEST.in` includes `README.md`, `README.rst`, `requirements.txt`, `CHANGELOG.md`, `LICENSE`; excludes `examples/`.
- `get_requirements()` tolerates a missing file and skips comments/blank lines.
- Long description falls back `README.md` → `README.rst`, with the content type following the file actually used.

**Verified**: both artifacts build, `twine check` passes on each, and the wheel installs and runs in a clean venv.